### PR TITLE
Add various utilities for performing actions "soon" (default 3 seconds).

### DIFF
--- a/Sources/UITestingPlus/XCTest+Soon.swift
+++ b/Sources/UITestingPlus/XCTest+Soon.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+
+
+/// The default amount of time to wait for functions and variables with "soon" in their name. 3 seconds.
+public enum XCTestSoon {
+    public static let defaultWaitTime: TimeInterval = 3
+}
+
+/// Returns true if `expression` evaluates to true within `waitTime` (default 3 seconds)
+public func IsTrueSoon(_ expression: @autoclosure () throws -> Bool, waitTime: TimeInterval = XCTestSoon.defaultWaitTime) -> Bool {
+    let startTime = Date()
+    repeat {
+        let success = (try? expression()) ?? false
+        if success {
+            return true
+        }
+        else {
+            Thread.sleep(forTimeInterval: 1)
+        }
+    }
+    while Date().timeIntervalSince(startTime) < waitTime
+    
+    return (try? expression()) ?? false
+}
+
+/// Drop-in replacement for `XCTAssert` that gives `waitTime` (default 3 seconds) for `expression` to evaluate to true
+public func XCTAssertSoon(_ expression: @autoclosure () throws -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, waitTime: TimeInterval = XCTestSoon.defaultWaitTime) {
+    XCTAssert(IsTrueSoon(try expression(), waitTime: waitTime), message(), file: file, line: line)
+}
+
+/// Drop-in replacement for XCTUnwrap that gives `waitTime` (default 3 seconds) for `expression` to evaluate to non-nil
+public func XCTUnwrapSoon<T>(_ expression: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, waitTime: TimeInterval = XCTestSoon.defaultWaitTime) throws -> T {
+    let startTime = Date()
+    repeat {
+        if let result = try? expression() {
+            return result
+        }
+        else {
+            Thread.sleep(forTimeInterval: 1)
+        }
+    }
+    while Date().timeIntervalSince(startTime) < waitTime
+    
+    return try XCTUnwrap(expression(), message(), file: file, line: line)
+}
+
+/// Drop-in replacement for `XCTAssertEqual` that gives `waitTime` (default 3 seconds) for `expression1` to evaluate to equal to `expression2`
+public func XCTAssertEqualSoon<T>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, waitTime: TimeInterval = XCTestSoon.defaultWaitTime) where T : Equatable {
+    if IsTrueSoon((try? expression1() == (try? expression2())) ?? false, waitTime: waitTime) {
+        return
+    }
+    
+    XCTAssertEqual(try? expression1(), try? expression2(), message(), file: file, line: line)
+
+}
+
+/// Drop-in replacement for `XCTAssertNotEqual` that gives `waitTime` (default 3 seconds) for `expression1` to evaluate not equal to `expression2`
+public func XCTAssertNotEqualSoon<T>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, waitTime: TimeInterval = XCTestSoon.defaultWaitTime) where T : Equatable {
+    if IsTrueSoon((try? expression1() != (try? expression2())) ?? false, waitTime: waitTime) {
+        return
+    }
+
+    XCTAssertNotEqual(try? expression1(), try? expression2(), message(), file: file, line: line)
+}

--- a/Sources/UITestingPlus/XCUIElement+Hittable.swift
+++ b/Sources/UITestingPlus/XCUIElement+Hittable.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-extension XCUIElement {
+public extension XCUIElement {
     
     /// Returns true if the element's `isHittable` property is true within `timeout` seconds
     func waitForHittable(timeout: TimeInterval) -> Bool {

--- a/Sources/UITestingPlus/XCUIElement+Hittable.swift
+++ b/Sources/UITestingPlus/XCUIElement+Hittable.swift
@@ -1,0 +1,27 @@
+import Foundation
+import XCTest
+
+extension XCUIElement {
+    
+    /// Returns true if the element's `isHittable` property is true within `timeout` seconds
+    func waitForHittable(timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "isHittable == 1")
+        let exp = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        
+        let result = XCTWaiter.wait(for: [exp], timeout: timeout)
+        
+        return result == .completed
+    }
+    
+    /// Returns true if the element's `isHittable` property is false within `timeout` seconds
+    func waitForNotHittable(timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "isHittable == 0")
+        let exp = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        
+        let result = XCTWaiter.wait(for: [exp], timeout: timeout)
+        
+        return result == .completed
+    }
+    
+    
+}

--- a/Sources/UITestingPlus/XCUIElement+Soon.swift
+++ b/Sources/UITestingPlus/XCUIElement+Soon.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-extension XCUIElement {
+public extension XCUIElement {
     
     /// Returns true if the element exists within 3 seconds
     var existsSoon: Bool {

--- a/Sources/UITestingPlus/XCUIElement+Soon.swift
+++ b/Sources/UITestingPlus/XCUIElement+Soon.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XCTest
+
+extension XCUIElement {
+    
+    /// Returns true if the element exists within 3 seconds
+    var existsSoon: Bool {
+        return waitForExistence(timeout: XCTestSoon.defaultWaitTime)
+    }
+
+    /// Returns true if the element does not exist within 3 seconds
+    var doesNotExistSoon: Bool {
+        return waitForNonExistence(timeout: XCTestSoon.defaultWaitTime)
+    }
+    
+    /// Returns true if the element's `isHittable` property is true within 3 seconds
+    var isHittableSoon: Bool {
+        return waitForHittable(timeout: XCTestSoon.defaultWaitTime)
+    }
+
+    /// Returns true if the element's `isHittable` property is false within 3 seconds
+    var isNotHittableSoon: Bool {
+        return waitForNotHittable(timeout: XCTestSoon.defaultWaitTime)
+    }
+    
+    /// Waits for the element to exist for `waitTime` (default 3 seconds), then taps the element. If it does not exist within `waitTime` seconds, causes a test assertion failure.
+    func tapSoon(file: StaticString = #filePath, line: UInt = #line, waitTime: TimeInterval = XCTestSoon.defaultWaitTime) {
+        XCTAssert(self.waitForExistence(timeout: waitTime), file: file, line: line)
+        self.tap()
+    }
+}


### PR DESCRIPTION
Given the sometimes flaky nature of the "wait for app to idle" mechanism, using these functions in place of their standard counterparts is a good way to reduce flaky test failures.

In my personal usage, I almost always use these `soon` variants in place of their non-soon versions, especially `existsSoon` and `tapSoon`. I have found that it reduces flakiness a lot, and avoids a lot of headaches at the yearly iOS release when Apple inevitably subtly changes the behavior of UITesting. When tests are passing, they don't add any extra time overhead, so there's not much of a downside to using them extensively. 

Places I don't use them are when I have a series of asserts in a row and I know the state isn't changing between them. Or when I actually care about the timing (although I avoid this as much as possible, since relying on timing usually leads to flakiness).